### PR TITLE
Added tests for how match scores appear in messages

### DIFF
--- a/app/handlers/showLaddersHandler.js
+++ b/app/handlers/showLaddersHandler.js
@@ -28,9 +28,9 @@ let showStatsHandler = function(persistence) {
     };
 };
 
-function _decorate(ladderName, shouldAddComa) {
+function _decorate(ladderName, shouldAddComma) {
     let decoratedName = '`' + ladderName + '`';
-    if (shouldAddComa) {
+    if (shouldAddComma) {
         decoratedName += ', ';
     }
 

--- a/app/handlers/showStatsHandler.js
+++ b/app/handlers/showStatsHandler.js
@@ -37,7 +37,7 @@ let showStatsHandler = function(persistence) {
                     return !match.winner;
                 });
 
-                let resultMessage = slackTextSnippets.playerStats(ladder.name, playerWins.length, notPlayedMatches.length, playerMatches, playerName, ladder.map.name);
+                let resultMessage = slackTextSnippets.playerStats(ladder.name, playerWins.length, notPlayedMatches.length, playerMatches, ladder.map.name);
 
                 let directResponseMessage = 'Your stats in this ladder were sent to you directly to your @slackbot channel.';
 

--- a/app/slackTextSnippets.js
+++ b/app/slackTextSnippets.js
@@ -86,7 +86,7 @@ function ranking(ladder) {
     return message;
 }
 
-function playerStats(ladderName, playerWinsCount, notPlayedMatches, playerMatches, requestingPlayerName, mapName) {
+function playerStats(ladderName, playerWinsCount, notPlayedMatches, playerMatches, mapName) {
     let playerMatchesCount = playerMatches.length;
 
     let playerLossCount = playerMatchesCount - playerWinsCount - notPlayedMatches;

--- a/app/slackTextSnippets.js
+++ b/app/slackTextSnippets.js
@@ -54,7 +54,7 @@ function _losingScoreFirst(score) {
 
 function _indicateWinner(playerName, match) {
     if (playerName === match.winner) {
-        return '`+' + playerName + '`';
+        return decorate('+' + playerName);
     }
 
     return playerName;

--- a/tests/slackTextSnippets.test.js
+++ b/tests/slackTextSnippets.test.js
@@ -5,7 +5,7 @@ import slackTextSnippets from '../app/slackTextSnippets';
 import sinon from 'sinon';
 
 describe('should display scores in the order players appear in message', () => {
-    it('when creating new match result notifcation', () => {
+    it('when creating new match result notification', () => {
         //given
 
         //when

--- a/tests/slackTextSnippets.test.js
+++ b/tests/slackTextSnippets.test.js
@@ -4,8 +4,8 @@ import assert from 'assertthat';
 import slackTextSnippets from '../app/slackTextSnippets';
 import sinon from 'sinon';
 
-describe('new match result notifcation', () => {
-    it('should display winner score first', () => {
+describe('should display scores in the order players appear in message', () => {
+    it('when creating new match result notifcation', () => {
         //given
 
         //when
@@ -17,5 +17,33 @@ describe('new match result notifcation', () => {
 
         assert.that(winningScoreFirst).is.equalTo(expectedMessage);
         assert.that(losingScoreFirst).is.equalTo(expectedMessage);
+    });
+
+    it('when creating ranking representation', () => {
+        //given
+        let ladder = {
+            name: 'ladder',
+            map: {
+                name: 'map'
+            },
+            matches: [
+                { player1: 'winner', player2: 'loser', winner: 'winner', score: '32:23' },
+                { player1: 'winner', player2: 'loser', winner: 'winner', score: '23:32' },
+                { player1: 'loser', player2: 'winner', winner: 'winner', score: '23:32' },
+                { player1: 'loser', player2: 'winner', winner: 'winner', score: '32:23' },
+            ]
+        };
+
+        let expectedMessage = '`ladder matches`\n' +
+        '[`+winner` vs loser 32:23 on map]\n' +
+        '[`+winner` vs loser 32:23 on map]\n' +
+        '[loser vs `+winner` 23:32 on map]\n' +
+        '[loser vs `+winner` 23:32 on map]\n';
+
+        //when
+        let rankingMessage = slackTextSnippets.ranking(ladder);
+        
+        //then
+        assert.that(rankingMessage).is.equalTo(expectedMessage);
     });
 });

--- a/tests/slackTextSnippets.test.js
+++ b/tests/slackTextSnippets.test.js
@@ -30,7 +30,7 @@ describe('should display scores in the order players appear in message', () => {
                 { player1: 'winner', player2: 'loser', winner: 'winner', score: '32:23' },
                 { player1: 'winner', player2: 'loser', winner: 'winner', score: '23:32' },
                 { player1: 'loser', player2: 'winner', winner: 'winner', score: '23:32' },
-                { player1: 'loser', player2: 'winner', winner: 'winner', score: '32:23' },
+                { player1: 'loser', player2: 'winner', winner: 'winner', score: '32:23' }
             ]
         };
 
@@ -45,5 +45,30 @@ describe('should display scores in the order players appear in message', () => {
         
         //then
         assert.that(rankingMessage).is.equalTo(expectedMessage);
+    });
+
+    it('when creating player stats message', () => {
+        //given
+        let playerWinsCount = 2;
+        let notPlayedMatches = 0;
+        let playerMatches = [
+            { player1: 'winner', player2: 'loser', winner: 'winner', score: '32:23' },
+            { player1: 'winner', player2: 'loser', winner: 'winner', score: '23:32' },
+            { player1: 'loser', player2: 'winner', winner: 'winner', score: '23:32' },
+            { player1: 'loser', player2: 'winner', winner: 'winner', score: '32:23' }
+        ];
+        
+        let expectedMessage = 'Ladder `ladderName`\n' +
+        'Matches: 4 / Wins: ' + playerWinsCount + ' / Losses: 2\n' +
+        '[`+winner` vs loser 32:23 on mapName]\n' +
+        '[`+winner` vs loser 32:23 on mapName]\n' +
+        '[loser vs `+winner` 23:32 on mapName]\n' +
+        '[loser vs `+winner` 23:32 on mapName]\n';
+
+        //when
+        let playerStatsMessage = slackTextSnippets.playerStats('ladderName', playerWinsCount, notPlayedMatches, playerMatches, 'requestingPlayerName', 'mapName');
+        
+        //then
+        assert.that(playerStatsMessage).is.equalTo(expectedMessage);
     });
 });

--- a/tests/slackTextSnippets.test.js
+++ b/tests/slackTextSnippets.test.js
@@ -66,7 +66,7 @@ describe('should display scores in the order players appear in message', () => {
         '[loser vs `+winner` 23:32 on mapName]\n';
 
         //when
-        let playerStatsMessage = slackTextSnippets.playerStats('ladderName', playerWinsCount, notPlayedMatches, playerMatches, 'requestingPlayerName', 'mapName');
+        let playerStatsMessage = slackTextSnippets.playerStats('ladderName', playerWinsCount, notPlayedMatches, playerMatches, 'mapName');
         
         //then
         assert.that(playerStatsMessage).is.equalTo(expectedMessage);


### PR DESCRIPTION
Let me know what you think about the slackTestSnippets test fixture - I kind of swapped the usual describe() and it() messages to group the test by behaviour rather than method - because that made more sense for me in this case

and it looks logical on mocha results:
![image](https://cloud.githubusercontent.com/assets/9142942/9394438/dd6410d8-4788-11e5-8252-41d9639678f9.png)

_UPDATE_
fixed test message typo you can see on the screen
